### PR TITLE
add UT to cover the case of recovering apps before nodes

### DIFF
--- a/pkg/scheduler/tests/scheduler_recovery_test.go
+++ b/pkg/scheduler/tests/scheduler_recovery_test.go
@@ -669,7 +669,7 @@ partitions:
 	assert.Equal(t, app01.ApplicationInfo.QueueName, "root.a")
 }
 
-// test scheduler recovery that only registers nodes and apps
+// test scheduler recovery that only registers apps
 func TestAppRecoveryAlone(t *testing.T) {
 	serviceContext := entrypoint.StartAllServicesWithManualScheduler()
 	proxy := serviceContext.RMProxy


### PR DESCRIPTION
During recovery, we need to send apps first before nodes. This UT is to add coverage for that.