### PR TITLE
application state is accepted after scheduler recovery

### DIFF
--- a/pkg/cache/partition_info.go
+++ b/pkg/cache/partition_info.go
@@ -169,6 +169,18 @@ func (pi *PartitionInfo) addNewNode(node *NodeInfo, existingAllocations []*si.Al
             zap.String("nodeId", node.NodeId),
             zap.Int("existingAllocations", len(existingAllocations)))
         for _, alloc := range existingAllocations {
+            // if this is to start processing existing allocations for an app,
+            // transit app's state from Accepted to Running
+            if app, ok := pi.applications[alloc.ApplicationId]; ok {
+                log.Logger.Info("", zap.String("state", app.GetApplicationState()))
+                if app.GetApplicationState() == Accepted.String() {
+                    if err := app.HandleApplicationEvent(RunApplication); err != nil {
+                        log.Logger.Warn("unable to handle app event - RunApplication",
+                            zap.Error(err))
+                    }
+                }
+            }
+
             if _, err := pi.addNodeReportedAllocations(alloc); err != nil {
                 log.Logger.Info("failed to add existing allocations",
                     zap.String("nodeId", node.NodeId),

--- a/pkg/scheduler/tests/scheduler_recovery_test.go
+++ b/pkg/scheduler/tests/scheduler_recovery_test.go
@@ -391,6 +391,9 @@ partitions:
 	assert.Equal(t, recoveredQueue.CachedQueueInfo.GetAllocatedResource().Resources[resources.VCORE], resources.Quantity(12))
 	assert.Equal(t, recoveredQueueRoot.CachedQueueInfo.GetAllocatedResource().Resources[resources.MEMORY], resources.Quantity(120))
 	assert.Equal(t, recoveredQueueRoot.CachedQueueInfo.GetAllocatedResource().Resources[resources.VCORE], resources.Quantity(12))
+
+	// verify app state
+	assert.Equal(t, recoveredApp.ApplicationInfo.GetApplicationState(), "Running")
 }
 
 // test scheduler recovery when shim doesn't report existing application
@@ -725,4 +728,23 @@ partitions:
 
 	waitForAcceptedApplications(mockRM, "app-1", 1000)
 	waitForAcceptedApplications(mockRM, "app-2", 1000)
+
+	// verify app state
+	apps := serviceContext.Cache.GetPartition("[rm:123]default").GetApplications()
+	var app1 *cacheInfo.ApplicationInfo
+	var app2 *cacheInfo.ApplicationInfo
+	for _, app := range apps {
+		if app.ApplicationId == "app-1" {
+			app1 = app
+		}
+
+		if app.ApplicationId == "app-2" {
+			app2 = app
+		}
+	}
+
+	assert.Assert(t, app1 != nil)
+	assert.Assert(t, app2 != nil)
+	assert.Equal(t, app1.GetApplicationState(), "Accepted")
+	assert.Equal(t, app2.GetApplicationState(), "Accepted")
 }


### PR DESCRIPTION
During recovery, when we start to processing existing allocations, we should transit app's state from Accepted to Running, this was missed in the initial patch for recovery, this PR is to fix this issue.