### PR TITLE
Remove strings.ReplaceAll for Go 1.11 compatibility

### DIFF
--- a/pkg/scheduler/placement/rule.go
+++ b/pkg/scheduler/placement/rule.go
@@ -109,5 +109,5 @@ func normalise(name string) string {
 
 // Replace all dots in the generated queue name before making it a fully qualified name.
 func replaceDot(name string) string {
-	return strings.ReplaceAll(name, cache.DOT, cache.DotReplace)
+	return strings.Replace(name, cache.DOT, cache.DotReplace, -1)
 }


### PR DESCRIPTION
Replace the new strings.ReplaceAll() method call with the old strings.Replace() call.

ReplaceAll was introduced in G0 1.12 as most of the calls use a -1 anyway.

Closes #37 