### PR TITLE
ACL and Filter use user regexp when they should use group regexp

### DIFF
--- a/pkg/common/security/acl.go
+++ b/pkg/common/security/acl.go
@@ -30,7 +30,10 @@ const (
     Space     = " "
 )
 
-var UserNameRegExp = regexp.MustCompile("^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\\$)$")
+// User and group regexp, must allow at least what we allow in the config checks
+// See configs.UserNameRegExp and configs.GroupRegExp
+var UserNameRegExp = regexp.MustCompile("^[_a-zA-Z][a-zA-Z0-9_.@-]*[$]?$")
+var GroupRegExp = regexp.MustCompile("^[_a-zA-Z][a-zA-Z0-9_-]*$")
 
 type ACL struct {
     users      map[string]bool
@@ -62,7 +65,7 @@ func (a *ACL) setUsers(userList []string) {
         if UserNameRegExp.MatchString(user) {
             a.users[user] = true
         } else {
-            log.Logger.Info("user Ignoring user in ACL definition",
+            log.Logger.Info("ignoring user in ACL definition",
                 zap.String("user", user))
         }
     }
@@ -88,7 +91,7 @@ func (a *ACL) setGroups(groupList []string) {
     }
     // add all groups to the map
     for _, group := range groupList {
-        if UserNameRegExp.MatchString(group) {
+        if GroupRegExp.MatchString(group) {
             a.groups[group] = true
         } else {
             log.Logger.Info("ignoring group in ACL",

--- a/pkg/common/security/acl.go
+++ b/pkg/common/security/acl.go
@@ -31,9 +31,9 @@ const (
 )
 
 // User and group regexp, must allow at least what we allow in the config checks
-// See configs.UserNameRegExp and configs.GroupRegExp
-var UserNameRegExp = regexp.MustCompile("^[_a-zA-Z][a-zA-Z0-9_.@-]*[$]?$")
-var GroupRegExp = regexp.MustCompile("^[_a-zA-Z][a-zA-Z0-9_-]*$")
+// See configs.UserNameRegExp and configs.GroupRegExp in the config validator.
+var userNameRegExp = regexp.MustCompile("^[_a-zA-Z][a-zA-Z0-9_.@-]*[$]?$")
+var groupRegExp = regexp.MustCompile("^[_a-zA-Z][a-zA-Z0-9_-]*$")
 
 type ACL struct {
     users      map[string]bool
@@ -62,7 +62,7 @@ func (a *ACL) setUsers(userList []string) {
     }
     // add all users to the map
     for _, user := range userList {
-        if UserNameRegExp.MatchString(user) {
+        if userNameRegExp.MatchString(user) {
             a.users[user] = true
         } else {
             log.Logger.Info("ignoring user in ACL definition",
@@ -91,7 +91,7 @@ func (a *ACL) setGroups(groupList []string) {
     }
     // add all groups to the map
     for _, group := range groupList {
-        if GroupRegExp.MatchString(group) {
+        if groupRegExp.MatchString(group) {
             a.groups[group] = true
         } else {
             log.Logger.Info("ignoring group in ACL",

--- a/pkg/scheduler/placement/filter.go
+++ b/pkg/scheduler/placement/filter.go
@@ -150,7 +150,7 @@ func newFilter(conf configs.Filter) Filter {
     if len(conf.Groups) >= 2 {
         for _, group := range conf.Groups {
             // sanity check the entry, do not add if it does not comply
-            if configs.UserRegExp.MatchString(group) {
+            if configs.GroupRegExp.MatchString(group) {
                 filter.groupList[group] = true
             }
         }


### PR DESCRIPTION
In the ACL and filter when we check the groups we use the less restrictive user regexp.
It does not break behaviour but we should be using the correct regexp to make sure the configuration is correctly checked.