### PR TITLE
Scheduler core logging picks up configured options from zap global logger

### DIFF
--- a/pkg/cache/application_state.go
+++ b/pkg/cache/application_state.go
@@ -84,7 +84,7 @@ func newAppState() *fsm.FSM {
 		},
 		fsm.Callbacks{
 			"enter_state": func(event *fsm.Event) {
-				log.Logger.Debug("app state transition",
+				log.Logger().Debug("app state transition",
 					zap.Any("app", event.Args[0]),
 					zap.String("source", event.Src),
 					zap.String("destination", event.Dst),

--- a/pkg/cache/initializer.go
+++ b/pkg/cache/initializer.go
@@ -42,7 +42,7 @@ func createPartitionInfos(clusterInfo *ClusterInfo, conf *configs.SchedulerConfi
 
         clusterInfo.addPartition(partitionName, partition)
         updatedPartitions = append(updatedPartitions, partition)
-        log.Logger.Info("added partition", zap.String("partition", partitionName))
+        log.Logger().Info("added partition", zap.String("partition", partitionName))
     }
 
     return updatedPartitions, nil
@@ -94,7 +94,7 @@ func UpdateClusterInfoFromConfigFile(clusterInfo *ClusterInfo, rmId string) ([]*
     configs.ConfigContext.Set(clusterInfo.policyGroup, conf)
 
     // Start updating the config is OK and should pass setting on the cluster
-    log.Logger.Info("updating partitions", zap.String("rmId", rmId))
+    log.Logger().Info("updating partitions", zap.String("rmId", rmId))
     // keep track of the deleted and updated partitions
     updatedPartitions := make([]*PartitionInfo, 0)
     visited := map[string]bool{}
@@ -110,14 +110,14 @@ func UpdateClusterInfoFromConfigFile(clusterInfo *ClusterInfo, rmId string) ([]*
                 return []*PartitionInfo{}, []*PartitionInfo{}, err
             }
             // checks passed perform the real update
-            log.Logger.Info("updating partitions", zap.String("partitionName", partitionName))
+            log.Logger().Info("updating partitions", zap.String("partitionName", partitionName))
             err = part.updatePartitionDetails(p)
             if err != nil {
                 return []*PartitionInfo{}, []*PartitionInfo{}, err
             }
         } else {
             // not found: new partition, no checks needed
-            log.Logger.Info("added partitions", zap.String("partitionName", partitionName))
+            log.Logger().Info("added partitions", zap.String("partitionName", partitionName))
 
             part, err = newPartitionInfo(p, rmId, clusterInfo)
             clusterInfo.addPartition(partitionName, part)
@@ -136,7 +136,7 @@ func UpdateClusterInfoFromConfigFile(clusterInfo *ClusterInfo, rmId string) ([]*
         if !visited[part.Name] {
             part.MarkPartitionForRemoval()
             deletedPartitions = append(deletedPartitions, part)
-            log.Logger.Info("marked partition for removal",
+            log.Logger().Info("marked partition for removal",
                 zap.String("partitionName", part.Name))
         }
     }

--- a/pkg/cache/object_state.go
+++ b/pkg/cache/object_state.go
@@ -73,7 +73,7 @@ func newObjectState() *fsm.FSM {
         },
         fsm.Callbacks{
             "enter_state": func(event *fsm.Event) {
-                log.Logger.Info("object transition",
+                log.Logger().Info("object transition",
                     zap.Any("object", event.Args[0]),
                     zap.String("source", event.Src),
                     zap.String("destination", event.Dst),

--- a/pkg/cache/queue_info.go
+++ b/pkg/cache/queue_info.go
@@ -87,7 +87,7 @@ func NewManagedQueue(conf configs.QueueConfig, parent *QueueInfo) (*QueueInfo, e
     }
 
     qi.metrics = metrics.InitQueueMetrics(conf.Name)
-    log.Logger.Debug("queue added",
+    log.Logger().Debug("queue added",
         zap.String("queueName", qi.Name),
         zap.String("queuePath", qi.GetQueuePath()))
     return qi, nil
@@ -201,7 +201,7 @@ func (qi *QueueInfo) IncAllocatedResource(alloc *resources.Resource, nodeReporte
     // check the parent: need to pass before updating
     if qi.Parent != nil {
         if err := qi.Parent.IncAllocatedResource(alloc, nodeReported); err != nil {
-            log.Logger.Error("parent queue exceeds maximum resource",
+            log.Logger().Error("parent queue exceeds maximum resource",
                 zap.Any("allocationId", alloc),
                 zap.Any("maxResource", qi.MaxResource),
                 zap.Error(err))
@@ -227,7 +227,7 @@ func (qi *QueueInfo) DecAllocatedResource(alloc *resources.Resource) error {
     // check the parent: need to pass before updating
     if qi.Parent != nil {
         if err := qi.Parent.DecAllocatedResource(alloc); err != nil {
-            log.Logger.Error("released allocation is larger than parent queue max resource",
+            log.Logger().Error("released allocation is larger than parent queue max resource",
                 zap.Any("allocationId", alloc),
                 zap.Any("maxResource", qi.MaxResource),
                 zap.Error(err))
@@ -276,7 +276,7 @@ func (qi *QueueInfo) RemoveQueue() bool {
         return false
     }
 
-    log.Logger.Info("removing queue", zap.String("queue", qi.Name))
+    log.Logger().Info("removing queue", zap.String("queue", qi.Name))
     // root is always managed and is the only queue with a nil parent: no need to guard
     qi.Parent.removeChildQueue(qi.Name)
     return true
@@ -292,10 +292,10 @@ func (qi *QueueInfo) MarkQueueForRemoval() {
     // Mark the managed queue for deletion: it is removed from the config let it drain.
     // Also mark all the managed children for deletion.
     if qi.isManaged {
-        log.Logger.Info("marking managed queue for deletion",
+        log.Logger().Info("marking managed queue for deletion",
             zap.String("queue", qi.GetQueuePath()))
         if err := qi.HandleQueueEvent(Remove); err != nil {
-            log.Logger.Info("failed to marking managed queue for deletion",
+            log.Logger().Info("failed to marking managed queue for deletion",
                 zap.String("queue", qi.GetQueuePath()),
                 zap.Error(err))
         }
@@ -313,19 +313,19 @@ func (qi *QueueInfo) updateQueueProps(conf configs.QueueConfig) error {
     var err error
     qi.submitACL, err = security.NewACL(conf.SubmitACL)
     if err != nil {
-        log.Logger.Error("parsing submit ACL failed this should not happen",
+        log.Logger().Error("parsing submit ACL failed this should not happen",
             zap.Error(err))
         return err
     }
     qi.adminACL, err = security.NewACL(conf.AdminACL)
     if err != nil {
-        log.Logger.Error("parsing admin ACL failed this should not happen",
+        log.Logger().Error("parsing admin ACL failed this should not happen",
             zap.Error(err))
         return err
     }
     // Change from unmanaged to managed
     if !qi.isManaged {
-        log.Logger.Info("changed un-managed queue to managed",
+        log.Logger().Info("changed un-managed queue to managed",
             zap.String("queue", qi.GetQueuePath()))
         qi.isManaged = true
     }
@@ -338,7 +338,7 @@ func (qi *QueueInfo) updateQueueProps(conf configs.QueueConfig) error {
     // Load the max resources
     maxResource, err := resources.NewResourceFromConf(conf.Resources.Max)
     if err != nil {
-        log.Logger.Error("parsing failed on max resources this should not happen",
+        log.Logger().Error("parsing failed on max resources this should not happen",
             zap.Error(err))
         return err
     }
@@ -349,7 +349,7 @@ func (qi *QueueInfo) updateQueueProps(conf configs.QueueConfig) error {
     // Load the guaranteed resources
     guaranteedResource, err := resources.NewResourceFromConf(conf.Resources.Guaranteed)
     if err != nil {
-        log.Logger.Error("parsing failed on max resources this should not happen",
+        log.Logger().Error("parsing failed on max resources this should not happen",
             zap.Error(err))
         return err
     }

--- a/pkg/common/configs/config.go
+++ b/pkg/common/configs/config.go
@@ -115,14 +115,14 @@ func LoadSchedulerConfigFromByteArray(content []byte) (*SchedulerConfig, error) 
     conf := &SchedulerConfig{}
     err := yaml.Unmarshal(content, conf)
     if err != nil {
-        log.Logger.Error("failed to parse queue configuration",
+        log.Logger().Error("failed to parse queue configuration",
             zap.Error(err))
         return nil, err
     }
     // validate the config
     err = Validate(conf)
     if err != nil {
-        log.Logger.Error("queue configuration validation failed",
+        log.Logger().Error("queue configuration validation failed",
             zap.Error(err))
         return nil, err
     }
@@ -134,11 +134,11 @@ func LoadSchedulerConfigFromByteArray(content []byte) (*SchedulerConfig, error) 
 
 func loadSchedulerConfigFromFile(policyGroup string) (*SchedulerConfig, error) {
     filePath := resolveConfigurationFileFunc(policyGroup)
-    log.Logger.Debug("loading configuration",
+    log.Logger().Debug("loading configuration",
         zap.String("configurationPath", filePath))
     buf, err := ioutil.ReadFile(filePath)
     if err != nil {
-        log.Logger.Error("failed to load configuration",
+        log.Logger().Error("failed to load configuration",
             zap.Error(err))
         return nil, err
     }

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -103,7 +103,7 @@ func checkPlacementRules(partition *PartitionConfig) error {
         return nil
     }
 
-    log.Logger.Debug("checking placement rule config",
+    log.Logger().Debug("checking placement rule config",
         zap.String("partitionName", partition.Name))
     // top level rule checks, parents are called recursively
     for _, rule := range partition.PlacementRules {
@@ -124,7 +124,7 @@ func checkPlacementRule(rule PlacementRule) error {
     // check the parent rule
     if rule.Parent != nil {
         if err := checkPlacementRule(*rule.Parent); err != nil {
-            log.Logger.Debug("parent placement rule failed",
+            log.Logger().Debug("parent placement rule failed",
                 zap.String("rule", rule.Name),
                 zap.String("parentRule", rule.Parent.Name))
             return err
@@ -132,7 +132,7 @@ func checkPlacementRule(rule PlacementRule) error {
     }
     // check filter if given
     if err := checkPlacementFilter(rule.Filter); err != nil {
-        log.Logger.Debug("placement rule filter failed",
+        log.Logger().Debug("placement rule filter failed",
             zap.String("rule", rule.Name),
             zap.Any("filter", rule.Filter))
         return err
@@ -183,7 +183,7 @@ func checkUserDefinition(partition *PartitionConfig) error {
         return nil
     }
 
-    log.Logger.Debug("checking partition user config",
+    log.Logger().Debug("checking partition user config",
         zap.String("partitionName", partition.Name))
     // TODO check users
     return nil
@@ -244,7 +244,7 @@ func checkQueuesStructure(partition *PartitionConfig) error {
         return fmt.Errorf("queue config is not set")
     }
 
-    log.Logger.Debug("checking partition queue config",
+    log.Logger().Debug("checking partition queue config",
         zap.String("partitionName", partition.Name))
 
     // handle no root queue cases
@@ -264,7 +264,7 @@ func checkQueuesStructure(partition *PartitionConfig) error {
 
     // insert the root queue if not there
     if insertRoot {
-        log.Logger.Debug("inserting root queue",
+        log.Logger().Debug("inserting root queue",
             zap.Int("numOfQueues", len(partition.Queues)))
         var rootQueue QueueConfig
         rootQueue.Name = RootQueue
@@ -310,7 +310,7 @@ func Validate(newConfig *SchedulerConfig) error {
             partition.Name = DefaultPartition
         }
         // check the queue structure
-        log.Logger.Debug("checking partition",
+        log.Logger().Debug("checking partition",
             zap.String("partitionName", partition.Name))
         err := checkQueuesStructure(&partition)
         if err != nil {

--- a/pkg/common/configs/configwatcher.go
+++ b/pkg/common/configs/configwatcher.go
@@ -80,7 +80,7 @@ func (cw *ConfigWatcher) runOnce() bool {
 
 	newConfig, err := SchedulerConfigLoader(cw.policyGroup)
 	if err != nil {
-		log.Logger.Warn("failed to calculate the checksum of configuration file for policyGroup," +
+		log.Logger().Warn("failed to calculate the checksum of configuration file for policyGroup," +
 			"ignore reloading configuration", zap.String("policyGroup", cw.policyGroup))
 		return false
 	}
@@ -89,14 +89,14 @@ func (cw *ConfigWatcher) runOnce() bool {
 	same := bytes.Equal(newConfig.Checksum, ConfigContext.Get(cw.policyGroup).Checksum)
 	if same {
 		// check sum equals, file not changed
-		log.Logger.Debug("configuration file unchanged")
+		log.Logger().Debug("configuration file unchanged")
 		time.Sleep(1 * time.Second)
 		return true
 	} else {
 		// when detect state changes, trigger the reload function
-		log.Logger.Debug("configuration file changed")
+		log.Logger().Debug("configuration file changed")
 		if err := cw.reloader.DoReloadConfiguration(); err == nil {
-			log.Logger.Debug("configuration is successfully reloaded")
+			log.Logger().Debug("configuration is successfully reloaded")
 		}
 		return false
 	}
@@ -129,6 +129,6 @@ func (cw *ConfigWatcher) Run() {
 			quit <- true
 		})
 	default:
-		log.Logger.Info("config watcher is already running")
+		log.Logger().Info("config watcher is already running")
 	}
 }

--- a/pkg/common/security/acl.go
+++ b/pkg/common/security/acl.go
@@ -56,7 +56,7 @@ func (a *ACL) setUsers(userList []string) {
     }
     // special case if the user list is just the wildcard
     if len(userList) == 1 && userList[0] == WildCard {
-        log.Logger.Info("user list is wildcard, allowing all access")
+        log.Logger().Info("user list is wildcard, allowing all access")
         a.allAllowed = true
         return
     }
@@ -65,7 +65,7 @@ func (a *ACL) setUsers(userList []string) {
         if userNameRegExp.MatchString(user) {
             a.users[user] = true
         } else {
-            log.Logger.Info("ignoring user in ACL definition",
+            log.Logger().Info("ignoring user in ACL definition",
                 zap.String("user", user))
         }
     }
@@ -80,11 +80,11 @@ func (a *ACL) setGroups(groupList []string) {
     }
     // special case if the wildcard was already set
     if a.allAllowed {
-        log.Logger.Info("ignoring group list in ACL: wildcard set")
+        log.Logger().Info("ignoring group list in ACL: wildcard set")
         return
     }
     if len(groupList) == 1 && groupList[0] == WildCard {
-        log.Logger.Info("group list is wildcard, allowing all access")
+        log.Logger().Info("group list is wildcard, allowing all access")
         a.users = make(map[string]bool)
         a.allAllowed = true
         return
@@ -94,7 +94,7 @@ func (a *ACL) setGroups(groupList []string) {
         if groupRegExp.MatchString(group) {
             a.groups[group] = true
         } else {
-            log.Logger.Info("ignoring group in ACL",
+            log.Logger().Info("ignoring group in ACL",
                 zap.String("group", group))
         }
     }

--- a/pkg/common/security/usergroup.go
+++ b/pkg/common/security/usergroup.go
@@ -66,17 +66,17 @@ func GetUserGroupCache(resolver string) *UserGroupCache {
     once.Do(func() {
         switch resolver {
         case "test":
-            log.Logger.Info("creating test user group resolver")
+            log.Logger().Info("creating test user group resolver")
             instance = GetUserGroupCacheTest()
         case "os":
-            log.Logger.Info("creating OS user group resolver")
+            log.Logger().Info("creating OS user group resolver")
             instance = GetUserGroupCacheOS()
         default:
-            log.Logger.Info("creating UserGroupCache without resolver")
+            log.Logger().Info("creating UserGroupCache without resolver")
             instance = GetUserGroupNoResolve()
         }
         instance.ugs = make(map[string]*UserGroup)
-        log.Logger.Info("starting UserGroupCache cleaner",
+        log.Logger().Info("starting UserGroupCache cleaner",
             zap.String("cleanerInterval", instance.interval.String()))
         go instance.run()
     })
@@ -89,7 +89,7 @@ func (c *UserGroupCache) run() {
         time.Sleep(instance.interval)
         runStart := time.Now()
         c.cleanUpCache()
-        log.Logger.Debug("time consumed cleaning the UserGroupCache",
+        log.Logger().Debug("time consumed cleaning the UserGroupCache",
             zap.String("duration", time.Since(runStart).String()))
     }
 }
@@ -112,7 +112,7 @@ func (c *UserGroupCache) cleanUpCache() {
 
 // reset the cached content, test use only
 func (c *UserGroupCache) resetCache() {
-    log.Logger.Debug("UserGroupCache reset")
+    log.Logger().Debug("UserGroupCache reset")
     instance.lock.Lock()
     defer instance.lock.Unlock()
     c.ugs = make(map[string]*UserGroup)
@@ -170,7 +170,7 @@ func (c *UserGroupCache) GetUserGroup(userName string) (UserGroup, error) {
     var err = error(nil)
     osUser, err = c.lookup(userName)
     if err != nil {
-        log.Logger.Error("Error resolving user: does not exist",
+        log.Logger().Error("Error resolving user: does not exist",
             zap.String("userName", userName),
             zap.Error(err))
         ug.failed = true
@@ -181,7 +181,7 @@ func (c *UserGroupCache) GetUserGroup(userName string) (UserGroup, error) {
         err = ug.resolveGroups(osUser, c)
         // log a failure and continue
         if err != nil {
-            log.Logger.Error("Error resolving groups for user",
+            log.Logger().Error("Error resolving groups for user",
                 zap.String("userName", userName),
                 zap.Error(err))
             ug.failed = true

--- a/pkg/common/server.go
+++ b/pkg/common/server.go
@@ -84,15 +84,15 @@ func ParseEndpoint(ep string) (string, string, error) {
 
 // Logging unary interceptor function to log every RPC call
 func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-    log.Logger.Debug("GPRC call",
+    log.Logger().Debug("GPRC call",
         zap.String("method", info.FullMethod))
-    log.Logger.Debug("GPRC request",
+    log.Logger().Debug("GPRC request",
         zap.String("request", fmt.Sprintf("%+v", req)))
     resp, err := handler(ctx, req)
     if err != nil {
-        log.Logger.Debug("GPRC error", zap.Error(err))
+        log.Logger().Debug("GPRC error", zap.Error(err))
     } else {
-        log.Logger.Debug("GPRC response",
+        log.Logger().Debug("GPRC response",
             zap.String("response", fmt.Sprintf("%+v", resp)))
     }
     return resp, err
@@ -107,13 +107,13 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ss si.SchedulerServer) {
 
     proto, addr, err := ParseEndpoint(endpoint)
     if err != nil {
-        log.Logger.Fatal("fatal error", zap.Error(err))
+        log.Logger().Fatal("fatal error", zap.Error(err))
     }
 
     if proto == "unix" {
         addr = "/" + addr
         if err := os.Remove(addr); err != nil && !os.IsNotExist(err) {
-            log.Logger.Fatal("failed to remove unix domain socket",
+            log.Logger().Fatal("failed to remove unix domain socket",
                 zap.String("uds", addr),
                 zap.Error(err))
         }
@@ -121,7 +121,7 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ss si.SchedulerServer) {
 
     listener, err := net.Listen(proto, addr)
     if err != nil {
-        log.Logger.Fatal("failed to listen to address",
+        log.Logger().Fatal("failed to listen to address",
             zap.Error(err))
     }
 
@@ -132,11 +132,11 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ss si.SchedulerServer) {
         si.RegisterSchedulerServer(server, ss)
     }
 
-    log.Logger.Info("listening for connections",
+    log.Logger().Info("listening for connections",
         zap.String("address", listener.Addr().String()))
 
     if err := server.Serve(listener); err != nil {
-        log.Logger.Fatal("failed to serve", zap.Error(err))
+        log.Logger().Fatal("failed to serve", zap.Error(err))
     }
 
 }

--- a/pkg/entrypoint/service_context.go
+++ b/pkg/entrypoint/service_context.go
@@ -36,7 +36,7 @@ func (s *ServiceContext) StopAll() {
 	// TODO implement stop for services
 	if s.WebApp != nil {
 		if err := s.WebApp.StopWebApp(); err != nil {
-			log.Logger.Error("failed to stop web-app",
+			log.Logger().Error("failed to stop web-app",
 				zap.Error(err))
 		}
 	}

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -46,10 +46,10 @@ func TestIsDebugEnabled(t *testing.T) {
 		Level: zap.NewAtomicLevelAt(zapcore.DebugLevel),
 		Encoding: "console",
 	}
-	if logger, err := zapConfigs.Build(); err != nil {
+	if newLogger, err := zapConfigs.Build(); err != nil {
 		assert.Fail(t, err.Error())
 	} else {
-		Logger = logger
+		logger = newLogger
 		assert.Equal(t, true, IsDebugEnabled())
 	}
 
@@ -57,10 +57,10 @@ func TestIsDebugEnabled(t *testing.T) {
 		Level: zap.NewAtomicLevelAt(zapcore.InfoLevel),
 		Encoding: "console",
 	}
-	if logger, err := zapConfigs.Build(); err != nil {
+	if newLogger, err := zapConfigs.Build(); err != nil {
 		assert.Fail(t, err.Error())
 	} else {
-		Logger = logger
+		logger = newLogger
 		assert.Equal(t, false, IsDebugEnabled())
 	}
 }

--- a/pkg/metrics/scheduler.go
+++ b/pkg/metrics/scheduler.go
@@ -195,11 +195,11 @@ func initSchedulerMetrics() *SchedulerMetrics {
 	}
 	// Expose the registered metrics via HTTP.
 	http.Handle("/metrics", promhttp.Handler())
-	log.Logger.Info("metrics started", zap.Int("servicePort", 9090))
+	log.Logger().Info("metrics started", zap.Int("servicePort", 9090))
 	go func() {
 		httpError := http.ListenAndServe(":9090", nil)
 		if httpError != nil {
-			log.Logger.Error("HTTP serving error", zap.Error(httpError))
+			log.Logger().Error("HTTP serving error", zap.Error(httpError))
 		}
 	}()
 

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -30,25 +30,25 @@ func init() {
 func RegisterSchedulerPlugin(plugin interface{}) {
 	registered := false
 	if t, ok := plugin.(PredicatesPlugin); ok {
-		log.Logger.Debug("register scheduler plugin",
+		log.Logger().Debug("register scheduler plugin",
 			zap.String("type", "PredicatesPlugin"))
 		plugins.predicatesPlugin = t
 		registered = true
 	}
 	if t, ok := plugin.(VolumesPlugin); ok {
-		log.Logger.Debug("register scheduler plugin",
+		log.Logger().Debug("register scheduler plugin",
 			zap.String("type", "VolumesPlugin"))
 		plugins.volumesPlugin = t
 		registered = true
 	}
 	if t, ok := plugin.(ReconcilePlugin); ok {
-		log.Logger.Debug("register scheduler plugin",
+		log.Logger().Debug("register scheduler plugin",
 			zap.String("type", "ReconcilePlugin"))
 		plugins.reconcilePlugin = t
 		registered = true
 	}
 	if !registered {
-		log.Logger.Debug("no scheduler plugin implemented, none registered")
+		log.Logger().Debug("no scheduler plugin implemented, none registered")
 	}
 }
 

--- a/pkg/rmproxy/rmproxy.go
+++ b/pkg/rmproxy/rmproxy.go
@@ -58,11 +58,11 @@ func (m *RMProxy) GetRMEventHandler() commonevents.EventHandler {
 func enqueueAndCheckFull(queue chan interface{}, ev interface{}) {
     select {
     case queue <- ev:
-        log.Logger.Debug("enqueue event",
+        log.Logger().Debug("enqueue event",
             zap.Any("event", ev),
             zap.Int("currentQueueSize", len(queue)))
     default:
-        log.Logger.Panic("failed to enqueue event",
+        log.Logger().Panic("failed to enqueue event",
             zap.String("event", reflect.TypeOf(ev).String()))
     }
 }
@@ -87,7 +87,7 @@ func (m *RMProxy) StartService(handlers handler.EventHandlers) {
 }
 
 func (m *RMProxy) handleRMRecvUpdateResponseError(rmId string, err error) {
-    log.Logger.Error("failed to handle response",
+    log.Logger().Error("failed to handle response",
         zap.String("rmId", rmId),
         zap.Error(err))
 }
@@ -101,7 +101,7 @@ func (m *RMProxy) processUpdateResponse(rmId string, response *si.UpdateResponse
             m.handleRMRecvUpdateResponseError(rmId, err)
         }
     } else {
-        log.Logger.DPanic("RM is not registered",
+        log.Logger().DPanic("RM is not registered",
             zap.String("rmId", rmId))
     }
 }

--- a/pkg/scheduler/allocator.go
+++ b/pkg/scheduler/allocator.go
@@ -76,7 +76,7 @@ func (m *Scheduler) singleStepSchedule(nAlloc int, preemptionParam *preemptionPa
                     m.eventHandlers.CacheEventHandler.HandleEvent(newSingleAllocationProposal(alloc))
                     confirmedAllocations = append(confirmedAllocations, alloc)
                 } else {
-                    log.Logger.Error("failed to send allocation proposal",
+                    log.Logger().Error("failed to send allocation proposal",
                         zap.Error(err))
                 }
             }
@@ -115,7 +115,7 @@ func (m *Scheduler) regularAllocate(nodes []*SchedulingNode, candidate *Scheduli
                         },
                     },
                 }); err != nil {
-                    log.Logger.Error("failed to sync cache",
+                    log.Logger().Error("failed to sync cache",
                         zap.Error(err))
                 }
             }
@@ -184,14 +184,14 @@ func (m *Scheduler) tryBatchAllocation(partition string, candidates []*Schedulin
 
     // Logging
     if len(allocations) > 0 || len(failedAsks) > 0 {
-        log.Logger.Debug("allocations cannot satisfy asks",
+        log.Logger().Debug("allocations cannot satisfy asks",
             zap.Int("numOfAllocations", len(allocations)),
             zap.Int("numOfFailedAsks", len(failedAsks)))
         if len(allocations) > 0 {
             if log.IsDebugEnabled() {
                 for _, alloc := range allocations {
                     if alloc != nil {
-                        log.Logger.Debug("allocation",
+                        log.Logger().Debug("allocation",
                             zap.Any("allocation", alloc))
                     }
                 }
@@ -201,7 +201,7 @@ func (m *Scheduler) tryBatchAllocation(partition string, candidates []*Schedulin
             if log.IsDebugEnabled() {
                 for _, failedAsk := range failedAsks {
                     if failedAsk != nil {
-                        log.Logger.Debug("failedAsks",
+                        log.Logger().Debug("failedAsks",
                             zap.Any("ask", failedAsk))
                     }
                 }

--- a/pkg/scheduler/asks_finder.go
+++ b/pkg/scheduler/asks_finder.go
@@ -185,13 +185,13 @@ func (m *Scheduler) findNextAllocationAskCandidate(
     for _, queue := range sortedQueueCandidates {
         // skip stopped queues: running and draining queues are allowed
         if queue.isStopped() {
-            log.Logger.Debug("skip non-running queue",
+            log.Logger().Debug("skip non-running queue",
                 zap.String("queueName", queue.Name))
             continue
         }
         // Is it need any resource?
         if !resources.StrictlyGreaterThanZero(queue.GetPendingResource()) {
-            log.Logger.Debug("skip queue because it has no pending resource",
+            log.Logger().Debug("skip queue because it has no pending resource",
                 zap.String("queueName", queue.Name))
             continue
         }
@@ -207,7 +207,7 @@ func (m *Scheduler) findNextAllocationAskCandidate(
             if preemptionParameters.crossQueuePreemption {
                 // We won't allocate resources if the queue is above its guaranteed resource.
                 if comp := resources.Comp(queue.CachedQueueInfo.GuaranteedResource, queue.ProposingResource, queue.CachedQueueInfo.GuaranteedResource); comp >= 0 {
-                    log.Logger.Debug("skip queue because it is already beyond guaranteed",
+                    log.Logger().Debug("skip queue because it is already beyond guaranteed",
                         zap.String("queueName", queue.Name))
                     continue
                 }

--- a/pkg/scheduler/partition_manager.go
+++ b/pkg/scheduler/partition_manager.go
@@ -44,7 +44,7 @@ func (manager PartitionManager) Run() {
         manager.interval = cleanerInterval * time.Millisecond
     }
 
-    log.Logger.Info("starting partition manager",
+    log.Logger().Info("starting partition manager",
         zap.String("partition", manager.psc.Name),
         zap.String("interval", manager.interval.String()))
     // exit only when the partition this manager belongs to exits
@@ -55,7 +55,7 @@ func (manager PartitionManager) Run() {
         if manager.stop {
             break
         }
-        log.Logger.Info("time consumed for queue cleaner",
+        log.Logger().Info("time consumed for queue cleaner",
             zap.String("duration", time.Since(runStart).String()))
     }
     manager.remove()
@@ -82,7 +82,7 @@ func (manager PartitionManager) cleanQueues(schedulingQueue *SchedulingQueue) {
     }
     // when we have done the children (or have none) this schedulingQueue might be removable
     if schedulingQueue.isDraining() || !schedulingQueue.isManaged() {
-        log.Logger.Debug("removing scheduling queue",
+        log.Logger().Debug("removing scheduling queue",
             zap.String("queueName", schedulingQueue.Name),
             zap.String("partitionName", manager.psc.Name))
         // make sure the queue is empty
@@ -92,7 +92,7 @@ func (manager PartitionManager) cleanQueues(schedulingQueue *SchedulingQueue) {
                 // all OK update the queue hierarchy and partition
                 schedulingQueue.RemoveQueue()
             } else {
-                log.Logger.Debug("failed to remove scheduling queue",
+                log.Logger().Debug("failed to remove scheduling queue",
                     zap.String("schedulingQueue", schedulingQueue.Name),
                     zap.String("queueAllocatedResource", schedulingQueue.CachedQueueInfo.GetAllocatedResource().String()),
                     zap.Int("numOfAssignedApps", 0),
@@ -100,7 +100,7 @@ func (manager PartitionManager) cleanQueues(schedulingQueue *SchedulingQueue) {
             }
         } else {
             // TODO time out waiting for draining and removal
-            log.Logger.Debug("failed to remove scheduling queue due to existing assigned apps",
+            log.Logger().Debug("failed to remove scheduling queue due to existing assigned apps",
                 zap.String("schedulingQueue", schedulingQueue.Name),
                 zap.String("partitionName", manager.psc.Name))
         }
@@ -114,14 +114,14 @@ func (manager PartitionManager) cleanQueues(schedulingQueue *SchedulingQueue) {
 // - nodes
 // last action is to remove the cluster links
 func (manager PartitionManager) remove() {
-    log.Logger.Info("marking all queues for removal",
+    log.Logger().Info("marking all queues for removal",
         zap.String("partitionName", manager.psc.Name))
     pi := manager.psc.partition
     // mark all queues for removal
     pi.Root.MarkQueueForRemoval()
     // remove applications: we do not care about return values or issues
     apps := pi.GetApplications()
-    log.Logger.Info("removing all applications from partition",
+    log.Logger().Info("removing all applications from partition",
         zap.Int("numOfApps",  len(apps)),
         zap.String("partitionName", manager.psc.Name))
     for i := range apps {
@@ -132,13 +132,13 @@ func (manager PartitionManager) remove() {
     }
     // remove the nodes
     nodes := pi.CopyNodeInfos()
-    log.Logger.Info("removing all nodes from partition",
+    log.Logger().Info("removing all nodes from partition",
         zap.Int("numOfNodes",  len(nodes)),
         zap.String("partitionName", manager.psc.Name))
     for i := range nodes {
         pi.RemoveNode(nodes[i].NodeId)
     }
-    log.Logger.Info("removing partition",
+    log.Logger().Info("removing partition",
         zap.String("partitionName", manager.psc.Name))
     // remove the cache object
     pi.Remove()

--- a/pkg/scheduler/placement/filter.go
+++ b/pkg/scheduler/placement/filter.go
@@ -46,7 +46,7 @@ func (filter Filter) allowUser(userObj security.UserGroup) bool {
     filteredUser := filter.filterUser(user)
     // if we have found the user in the list stop looking and return
     if filteredUser {
-        log.Logger.Debug("Filter matched user getName", zap.String("user", user))
+        log.Logger().Debug("Filter matched user getName", zap.String("user", user))
         return filteredUser && filter.allow
     }
     // not in the user list, check the groups in the list
@@ -54,7 +54,7 @@ func (filter Filter) allowUser(userObj security.UserGroup) bool {
     for _, group := range groups {
         filteredUser = filter.filterGroup(group)
         if filteredUser {
-            log.Logger.Debug("Filter matched user group", zap.String("group", group))
+            log.Logger().Debug("Filter matched user group", zap.String("group", group))
             return filteredUser && filter.allow
         }
     }
@@ -99,7 +99,7 @@ func newFilter(conf configs.Filter) Filter {
         if configs.SpecialRegExp.MatchString(conf.Users[0]) {
             filter.userExp, err = regexp.Compile(conf.Users[0])
             if err != nil {
-                log.Logger.Debug("Filter user expression does not compile", zap.Any("userFilter", conf.Users))
+                log.Logger().Debug("Filter user expression does not compile", zap.Any("userFilter", conf.Users))
             }
         } else {
             // regexp not found consider this a user, sanity check the entry
@@ -119,14 +119,14 @@ func newFilter(conf configs.Filter) Filter {
             }
         }
         if len(filter.userList) != len(conf.Users) {
-            log.Logger.Info("Filter creation duplicate or invalid users found", zap.Any("userFilter", conf.Users))
+            log.Logger().Info("Filter creation duplicate or invalid users found", zap.Any("userFilter", conf.Users))
         }
         filter.empty = false
     }
 
     // check what we have created
     if len(conf.Users) > 0 && filter.userExp == nil && len(filter.userList) == 0 {
-        log.Logger.Info("Filter creation partially failed (user)", zap.Any("userFilter", conf.Users))
+        log.Logger().Info("Filter creation partially failed (user)", zap.Any("userFilter", conf.Users))
     }
 
     // create the group list or regexp
@@ -135,7 +135,7 @@ func newFilter(conf configs.Filter) Filter {
         if configs.SpecialRegExp.MatchString(conf.Groups[0]) {
             filter.groupExp, err = regexp.Compile(conf.Groups[0])
             if err != nil {
-                log.Logger.Debug("Filter group expression does not compile", zap.Any("groupFilter", conf.Groups))
+                log.Logger().Debug("Filter group expression does not compile", zap.Any("groupFilter", conf.Groups))
             }
         } else {
             // regexp not found consider this a group, sanity check the entry
@@ -155,14 +155,14 @@ func newFilter(conf configs.Filter) Filter {
             }
         }
         if len(filter.groupList) != len(conf.Groups) {
-            log.Logger.Info("Filter creation duplicate or invalid groups found", zap.Any("groupFilter", conf.Groups))
+            log.Logger().Info("Filter creation duplicate or invalid groups found", zap.Any("groupFilter", conf.Groups))
         }
         filter.empty = false
     }
 
     // check what we have created
     if len(conf.Groups) > 0 && filter.groupExp == nil && len(filter.groupList) == 0 {
-        log.Logger.Info("Filter creation partially failed (groups)", zap.Any("groupFilter", conf.Groups))
+        log.Logger().Info("Filter creation partially failed (groups)", zap.Any("groupFilter", conf.Groups))
     }
 
     // log the filter with all details (only at debug)
@@ -178,7 +178,7 @@ func newFilter(conf configs.Filter) Filter {
         } else {
             groupfilter = filter.groupExp.String()
         }
-        log.Logger.Debug("Filter creation passed",
+        log.Logger().Debug("Filter creation passed",
             zap.Bool("allow", filter.allow),
             zap.Bool("empty", filter.empty),
             zap.Any("userList", filter.userList),

--- a/pkg/scheduler/placement/fixed_rule.go
+++ b/pkg/scheduler/placement/fixed_rule.go
@@ -61,7 +61,7 @@ func (fr *fixedRule) initialise(conf configs.PlacementRule) error {
 func (fr *fixedRule) placeApplication(app *cache.ApplicationInfo, info *cache.PartitionInfo) (string, error) {
     // before anything run the filter
     if !fr.filter.allowUser(app.GetUser()) {
-        log.Logger.Debug("Fixed rule filtered",
+        log.Logger().Debug("Fixed rule filtered",
             zap.String("application", app.ApplicationId),
             zap.Any("user", app.GetUser()),
             zap.String("queueName", fr.queue))
@@ -98,7 +98,7 @@ func (fr *fixedRule) placeApplication(app *cache.ApplicationInfo, info *cache.Pa
         queueName = parentName + cache.DOT + fr.queue
     }
     // Log the result before we really create
-    log.Logger.Debug("Fixed rule intermediate result",
+    log.Logger().Debug("Fixed rule intermediate result",
         zap.String("application", app.ApplicationId),
         zap.String("queue", queueName))
     // get the queue object
@@ -107,7 +107,7 @@ func (fr *fixedRule) placeApplication(app *cache.ApplicationInfo, info *cache.Pa
     if !fr.create && queue == nil {
         return "", nil
     }
-    log.Logger.Info("Fixed rule application placed",
+    log.Logger().Info("Fixed rule application placed",
         zap.String("application", app.ApplicationId),
         zap.String("queue", queueName))
     return queueName, nil

--- a/pkg/scheduler/placement/provided_rule.go
+++ b/pkg/scheduler/placement/provided_rule.go
@@ -54,7 +54,7 @@ func (pr *providedRule) placeApplication(app *cache.ApplicationInfo, info *cache
     }
     // before anything run the filter
     if !pr.filter.allowUser(app.GetUser()) {
-        log.Logger.Debug("Provided rule filtered",
+        log.Logger().Debug("Provided rule filtered",
             zap.String("application", app.ApplicationId),
             zap.Any("user", app.GetUser()))
         return "", nil
@@ -90,7 +90,7 @@ func (pr *providedRule) placeApplication(app *cache.ApplicationInfo, info *cache
         // Make it a fully qualified queue
         queueName = parentName + cache.DOT + replaceDot(queueName)
     }
-    log.Logger.Debug("Provided rule intermediate result",
+    log.Logger().Debug("Provided rule intermediate result",
         zap.String("application", app.ApplicationId),
         zap.String("queue", queueName))
     // get the queue object
@@ -99,7 +99,7 @@ func (pr *providedRule) placeApplication(app *cache.ApplicationInfo, info *cache
     if !pr.create && queue == nil {
         return "", nil
     }
-    log.Logger.Info("Provided rule application placed",
+    log.Logger().Info("Provided rule application placed",
         zap.String("application", app.ApplicationId),
         zap.String("queue", queueName))
     return queueName, nil

--- a/pkg/scheduler/placement/rule.go
+++ b/pkg/scheduler/placement/rule.go
@@ -94,10 +94,10 @@ func newRule(conf configs.PlacementRule) (rule, error) {
 	// initialise the rule: do not expect the rule to log errors
 	err = newRule.initialise(conf)
 	if err != nil {
-		log.Logger.Error("Rule init failed", zap.Error(err))
+		log.Logger().Error("Rule init failed", zap.Error(err))
 		return nil, err
 	}
-	log.Logger.Debug("New rule created", zap.Any("ruleConf", conf))
+	log.Logger().Debug("New rule created", zap.Any("ruleConf", conf))
 	return newRule, nil
 }
 

--- a/pkg/scheduler/placement/tag_rule.go
+++ b/pkg/scheduler/placement/tag_rule.go
@@ -60,7 +60,7 @@ func (tr *tagRule) placeApplication(app *cache.ApplicationInfo, info *cache.Part
     }
     // before anything run the filter
     if !tr.filter.allowUser(app.GetUser()) {
-        log.Logger.Debug("Tag rule filtered",
+        log.Logger().Debug("Tag rule filtered",
             zap.String("application", app.ApplicationId),
             zap.Any("user", app.GetUser()),
             zap.String("tagName", tr.tagName))
@@ -96,7 +96,7 @@ func (tr *tagRule) placeApplication(app *cache.ApplicationInfo, info *cache.Part
         }
         queueName = parentName + cache.DOT + replaceDot(tagVal)
     }
-    log.Logger.Debug("Tag rule intermediate result",
+    log.Logger().Debug("Tag rule intermediate result",
         zap.String("application", app.ApplicationId),
         zap.String("queue", queueName))
     // get the queue object
@@ -105,7 +105,7 @@ func (tr *tagRule) placeApplication(app *cache.ApplicationInfo, info *cache.Part
     if !tr.create && queue == nil {
         return "", nil
     }
-    log.Logger.Info("Tag rule application placed",
+    log.Logger().Info("Tag rule application placed",
         zap.String("application", app.ApplicationId),
         zap.String("queue", queueName))
     return queueName, nil

--- a/pkg/scheduler/placement/user_rule.go
+++ b/pkg/scheduler/placement/user_rule.go
@@ -48,7 +48,7 @@ func (ur *userRule) placeApplication(app *cache.ApplicationInfo, info *cache.Par
     // before anything run the filter
     userName := app.GetUser().User
     if !ur.filter.allowUser(app.GetUser()) {
-        log.Logger.Debug("User rule filtered",
+        log.Logger().Debug("User rule filtered",
             zap.String("application", app.ApplicationId),
             zap.Any("user", app.GetUser()))
         return "", nil
@@ -79,7 +79,7 @@ func (ur *userRule) placeApplication(app *cache.ApplicationInfo, info *cache.Par
         parentName = configs.RootQueue
     }
     queueName := parentName + cache.DOT + replaceDot(userName)
-    log.Logger.Debug("User rule intermediate result",
+    log.Logger().Debug("User rule intermediate result",
         zap.String("application", app.ApplicationId),
         zap.String("queue", queueName))
     // get the queue object
@@ -88,7 +88,7 @@ func (ur *userRule) placeApplication(app *cache.ApplicationInfo, info *cache.Par
     if !ur.create && queue == nil {
         return "", nil
     }
-    log.Logger.Info("User rule application placed",
+    log.Logger().Info("User rule application placed",
         zap.String("application", app.ApplicationId),
         zap.String("queue", queueName))
     return queueName, nil

--- a/pkg/scheduler/scheduling_context.go
+++ b/pkg/scheduler/scheduling_context.go
@@ -112,7 +112,7 @@ func (csc *ClusterSchedulingContext) RemoveSchedulingApplication(appId string, p
 func (csc *ClusterSchedulingContext) updateSchedulingPartitions(partitions []*cache.PartitionInfo) error {
     csc.lock.Lock()
     defer csc.lock.Unlock()
-    log.Logger.Info("updating scheduler context",
+    log.Logger().Info("updating scheduler context",
         zap.Int("numOfPartitionsUpdated", len(partitions)))
 
     // Walk over the updated partitions
@@ -121,12 +121,12 @@ func (csc *ClusterSchedulingContext) updateSchedulingPartitions(partitions []*ca
 
         partition := csc.partitions[updatedPartition.Name]
         if partition != nil {
-            log.Logger.Info("updating scheduling partition",
+            log.Logger().Info("updating scheduling partition",
                 zap.String("partitionName", updatedPartition.Name))
             // the partition details don't need updating just the queues
             partition.updatePartitionSchedulingContext(updatedPartition)
         } else {
-            log.Logger.Info("creating scheduling partition",
+            log.Logger().Info("creating scheduling partition",
                 zap.String("partitionName", updatedPartition.Name))
             // create a new partition and add the queues
             root := NewSchedulingQueueInfo(updatedPartition.Root, nil)
@@ -172,7 +172,7 @@ func (csc *ClusterSchedulingContext) deleteSchedulingPartitions(partitions []*ca
     for _, deletedPartition := range partitions {
         partition := csc.partitions[deletedPartition.Name]
         if partition != nil {
-            log.Logger.Info("marking scheduling partition for deletion",
+            log.Logger().Info("marking scheduling partition for deletion",
                 zap.String("partitionName", deletedPartition.Name))
             partition.partitionManager.Stop()
         } else {

--- a/pkg/scheduler/scheduling_node.go
+++ b/pkg/scheduler/scheduling_node.go
@@ -72,14 +72,14 @@ func (m *SchedulingNode) CheckAndAllocateResource(delta *resources.Resource, pre
 func (m *SchedulingNode) CheckAllocateConditions(allocId string) bool {
 	// Check the predicates plugin (k8shim)
 	if plugin := plugins.GetPredicatesPlugin(); plugin != nil {
-		log.Logger.Debug("predicates",
+		log.Logger().Debug("predicates",
 			zap.String("allocationId", allocId),
 			zap.String("nodeId", m.NodeId))
 		if err := plugin.Predicates(&si.PredicatesArgs{
 			AllocationKey: allocId,
 			NodeId:        m.NodeId,
 		}); err != nil {
-			log.Logger.Debug("running predicates failed",
+			log.Logger().Debug("running predicates failed",
 				zap.String("allocationId", allocId),
 				zap.String("nodeId", m.NodeId),
 				zap.Error(err))

--- a/pkg/scheduler/scheduling_partition.go
+++ b/pkg/scheduler/scheduling_partition.go
@@ -60,13 +60,13 @@ func (psc *PartitionSchedulingContext) updatePartitionSchedulingContext(info *ca
     defer psc.lock.Unlock()
 
     if psc.placementManager.IsInitialised() {
-        log.Logger.Info("Updating placement manager rules on config reload")
+        log.Logger().Info("Updating placement manager rules on config reload")
         err := psc.placementManager.UpdateRules(info.GetRules())
         if err != nil {
-            log.Logger.Info("New placement rules not activated, config reload failed", zap.Error(err))
+            log.Logger().Info("New placement rules not activated, config reload failed", zap.Error(err))
         }
     } else {
-        log.Logger.Info("Creating new placement manager on config reload")
+        log.Logger().Info("Creating new placement manager on config reload")
         psc.placementManager = placement.NewPlacementManager(info)
     }
     root := psc.Root
@@ -208,12 +208,12 @@ func (psc *PartitionSchedulingContext) createSchedulingQueue(name string, user s
     // Check the ACL before we really create
     // The existing parent scheduling queue is the lowest we need to look at
     if !parent.CheckSubmitAccess(user) {
-        log.Logger.Debug("Submit access denied by scheduler on queue",
+        log.Logger().Debug("Submit access denied by scheduler on queue",
             zap.String("deniedQueueName", schedQueue),
             zap.String("requestedQueue", name))
         return
     }
-    log.Logger.Debug("Creating scheduling queue(s)",
+    log.Logger().Debug("Creating scheduling queue(s)",
         zap.String("parent", schedQueue),
         zap.String("child", cacheQueue),
         zap.String("fullPath", name))

--- a/pkg/scheduler/scheduling_queue.go
+++ b/pkg/scheduler/scheduling_queue.go
@@ -91,7 +91,7 @@ func (sq *SchedulingQueue) updateSchedulingQueueProperties(prop map[string]strin
                 sq.ApplicationSortType = FairSortPolicy
             }
             // for now skip the rest just log them
-            log.Logger.Debug("queue property skipped",
+            log.Logger().Debug("queue property skipped",
                 zap.String("key", key),
                 zap.String("value", value))
         }

--- a/pkg/webservice/webservice.go
+++ b/pkg/webservice/webservice.go
@@ -60,7 +60,7 @@ func Logger(inner http.Handler, name string, info *cache.ClusterInfo) http.Handl
 
 		inner.ServeHTTP(w, r)
 
-		log.Logger.Debug(fmt.Sprintf("%s\t%s\t%s\t%s",
+		log.Logger().Debug(fmt.Sprintf("%s\t%s\t%s\t%s",
 			r.Method, r.RequestURI, name, time.Since(start)))
 	})
 }
@@ -69,11 +69,11 @@ func (m *WebService) StartWebApp() {
 	router := NewRouter(m.clusterInfo)
 	m.httpServer = &http.Server{Addr: ":9080", Handler: router}
 
-	log.Logger.Info("web-app started", zap.Int("port", 9080))
+	log.Logger().Info("web-app started", zap.Int("port", 9080))
 	go func() {
 		httpError := m.httpServer.ListenAndServe()
 		if httpError != nil && httpError != http.ErrServerClosed{
-			log.Logger.Error("HTTP serving error",
+			log.Logger().Error("HTTP serving error",
 				zap.Error(httpError))
 		}
 	}()


### PR DESCRIPTION
During testing, found earlier this was not working, this is because the logger in the core was initiated in the `init()` function, which will be loaded before shim initiates its logger (where it loads configurations from CLI). The fix is to remove `init()` function, and use a lazy init with sync.once instead.