### PR TITLE
Fix a potential race condition in scheduler smoke test

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -40,6 +40,10 @@ func Logger() *zap.Logger {
 }
 
 func IsDebugEnabled() bool {
+	if logger == nil {
+		// when under development mode
+		return true
+	}
 	return logger.Core().Enabled(zapcore.DebugLevel)
 }
 

--- a/pkg/scheduler/tests/scheduler_smoke_test.go
+++ b/pkg/scheduler/tests/scheduler_smoke_test.go
@@ -1069,7 +1069,7 @@ partitions:
             assert.Assert(t, app1 != nil)
             assert.Equal(t, len(app1.GetAllAllocations()), 10)
             assert.Assert(t, app1.GetAllocatedResource().Resources[resources.MEMORY] == 100)
-            assert.Equal(t, len(mockRM.Allocations), 10)
+            assert.Equal(t, len(mockRM.getAllocations()), 10)
 
             // release all allocated allocations
             allocReleases := make([]*si.AllocationReleaseRequest, 0)
@@ -1096,7 +1096,7 @@ partitions:
             }
 
             waitForPendingResource(t, schedulingQueue, 0, 1000)
-            assert.Equal(t, len(mockRM.Allocations), 2)
+            assert.Equal(t, len(mockRM.getAllocations()), 2)
         })
     }
 }

--- a/pkg/scheduler/tests/schedulertestutils.go
+++ b/pkg/scheduler/tests/schedulertestutils.go
@@ -97,6 +97,17 @@ func (m *MockRMCallbackHandler) RecvUpdateResponse(response *si.UpdateResponse) 
     return nil
 }
 
+func (m *MockRMCallbackHandler) getAllocations() map[string]*si.Allocation {
+    m.lock.RLock()
+    defer m.lock.RUnlock()
+
+    allocations := make(map[string]*si.Allocation)
+    for key, value := range m.Allocations {
+        allocations[key] = value
+    }
+    return allocations
+}
+
 func waitForAcceptedApplications(m *MockRMCallbackHandler, appId string, timeoutMs int) {
     var i = 0
     for {


### PR DESCRIPTION
There are some thread-safe issues in the mocked scheduler callback.