### PR TITLE
queue-usage-ratio should be compared separately when sorting queues

### DIFF
--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -369,6 +369,18 @@ func CompUsageRatio(left, right, total *Resource) int {
     return compareShares(lshares, rshares)
 }
 
+// Calculate share for left of total and right of total separately.
+// This returns the same value as compareShares does:
+// 0 for equal shares
+// 1 if the left share is larger
+// -1 if the right share is larger
+func CompUsageRatioSeparately(left, leftTotal, right, rightTotal *Resource) int {
+    lshares := getShares(left, leftTotal)
+    rshares := getShares(right, rightTotal)
+
+    return compareShares(lshares, rshares)
+}
+
 // Compare two resources usage shares and assumes a nil total resource.
 // The share is thus equivalent to the usage passed in.
 // This returns the same value as compareShares does:

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -1107,7 +1107,7 @@ func TestFairnessRatio(t *testing.T) {
     }
 }
 
-// This tests just to cover code in the CompUsageRatio and CompUsageShare.
+// This tests just to cover code in the CompUsageRatio, CompUsageRatioSeparately and CompUsageShare.
 // This does not check the share calculation and share comparison see TestGetShares and TestCompShares for that.
 func TestCompUsage(t *testing.T) {
     // simple case all empty or nil behaviour
@@ -1137,5 +1137,20 @@ func TestCompUsage(t *testing.T) {
     }
     if CompUsageRatio(left, right, total) != -1 {
         t.Errorf("right resources ratio should have been larger left %v, right %v", left, right)
+    }
+
+    // test for CompUsageRatioSeparately
+    left = &Resource{Resources: map[string]Quantity{"first": 50, "second": 50, "third": 50}}
+    right = &Resource{Resources: map[string]Quantity{"first": 10, "second": 10, "third": 10}}
+    leftTotal := &Resource{Resources: map[string]Quantity{"first": 100, "second": 100, "third": 100}}
+    rightTotal := leftTotal
+    if CompUsageRatioSeparately(left, leftTotal, right, rightTotal) != 1 {
+        t.Errorf("left resources ratio should have been larger left %v, left-total %v right %v right-total %v",
+            left, total, right, rightTotal)
+    }
+    rightTotal = &Resource{Resources: map[string]Quantity{"first": 10, "second": 10, "third": 10}}
+    if CompUsageRatioSeparately(left, leftTotal, right, rightTotal) != -1 {
+        t.Errorf("right resources ratio should have been larger left %v, left-total %v right %v right-total %v",
+            left, rightTotal, right, total)
     }
 }

--- a/pkg/scheduler/sorters.go
+++ b/pkg/scheduler/sorters.go
@@ -39,7 +39,8 @@ func SortQueue(queues []*SchedulingQueue, sortType SortType) {
             l := queues[i]
             r := queues[j]
 
-            comp := resources.CompUsageRatio(l.ProposingResource, r.ProposingResource, l.CachedQueueInfo.GuaranteedResource)
+            comp := resources.CompUsageRatioSeparately(l.ProposingResource, l.CachedQueueInfo.GuaranteedResource,
+                r.ProposingResource, r.CachedQueueInfo.GuaranteedResource)
             return comp < 0
         })
     }

--- a/pkg/scheduler/sorters_test.go
+++ b/pkg/scheduler/sorters_test.go
@@ -61,20 +61,32 @@ func TestSortQueues(t *testing.T) {
 		"memory": resources.Quantity(100),
 		"vcore" : resources.Quantity(100)})
 
+	// fairness ratios: q0:300/500=0.6, q1:200/300=0.67, q2:100/200=0.5
 	queues := []*SchedulingQueue{q0, q1, q2}
-	SortQueue(queues, FairSortPolicy)
-	assert.Equal(t, len(queues), 3)
-	assert.Equal(t, "root.q2", queues[0].Name)
-	assert.Equal(t, "root.q1", queues[1].Name)
-	assert.Equal(t, "root.q0", queues[2].Name)
-
-	q0.ProposingResource = resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 200, "vcore": 200})
-	q1.ProposingResource = resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 300, "vcore": 300})
 	SortQueue(queues, FairSortPolicy)
 	assert.Equal(t, len(queues), 3)
 	assert.Equal(t, "root.q2", queues[0].Name)
 	assert.Equal(t, "root.q0", queues[1].Name)
 	assert.Equal(t, "root.q1", queues[2].Name)
+
+	// fairness ratios: q0:200/500=0.4, q1:300/300=1, q2:100/200=0.5
+	q0.ProposingResource = resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 200, "vcore": 200})
+	q1.ProposingResource = resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 300, "vcore": 300})
+	SortQueue(queues, FairSortPolicy)
+	assert.Equal(t, len(queues), 3)
+	assert.Equal(t, "root.q0", queues[0].Name)
+	assert.Equal(t, "root.q2", queues[1].Name)
+	assert.Equal(t, "root.q1", queues[2].Name)
+
+	// fairness ratios: q0:150/500=0.3, q1:120/300=0.4, q2:100/200=0.5
+	q0.ProposingResource = resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 150, "vcore": 150})
+	q1.ProposingResource = resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 120, "vcore": 120})
+	q2.ProposingResource = resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 100, "vcore": 100})
+	SortQueue(queues, FairSortPolicy)
+	assert.Equal(t, len(queues), 3)
+	assert.Equal(t, "root.q0", queues[0].Name)
+	assert.Equal(t, "root.q1", queues[1].Name)
+	assert.Equal(t, "root.q2", queues[2].Name)
 }
 
 // queue guaranteed resource is 0


### PR DESCRIPTION
For example:
queue1: allocated-resource:50, guaranteed-resource:100, usage-ratio=50/100=0.5
queue2: allocated-resource:100, guaranteed-resource:300, usage-ratio=0.33
After sorting queues, queue2 should be placed before queue1, but current result is opposite.