### PR TITLE
Improve scheduler perf test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ build: commands
 .PHONY: test
 test:
 	@echo "running unit tests"
-	go test ./... -cover $(RACE) -tags deadlock
+	go test ./... -cover $(RACE) -tags deadlock -short
 	go vet $(REPO)...
 
 # Simple clean of generated files only (no local cleanup).

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ build: commands
 .PHONY: test
 test:
 	@echo "running unit tests"
-	go test ./... -cover $(RACE) -tags deadlock -short
+	go test ./... -cover $(RACE) -tags deadlock
 	go vet $(REPO)...
 
 # Simple clean of generated files only (no local cleanup).

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -25,6 +25,7 @@ import (
 
 var once sync.Once
 var logger *zap.Logger
+var config *zap.Config
 
 func Logger() *zap.Logger {
 	once.Do(func() {
@@ -33,7 +34,9 @@ func Logger() *zap.Logger {
 			// is running as a deployment mode, or running with another non-go code
 			// shim. In this case, we need to create our own logger.
 			// TODO support log options when a global logger is not there
-			logger, _= zap.NewDevelopment()
+			c := zap.NewDevelopmentConfig()
+			config = &c
+			logger, _= config.Build()
 		}
 	})
 	return logger
@@ -54,4 +57,12 @@ func IsDebugEnabled() bool {
 // the context, yunikorn-core can simply reuse it.
 func isNopLogger(logger *zap.Logger) bool {
 	return reflect.DeepEqual(zap.NewNop(), logger)
+}
+
+// Visible by tests
+func InitAndSetLevel(level zapcore.Level) {
+	if config == nil {
+		Logger()
+	}
+	config.Level.SetLevel(level)
 }

--- a/pkg/scheduler/tests/scheduler_perf_test.go
+++ b/pkg/scheduler/tests/scheduler_perf_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tests
 
 import (
+    "fmt"
     "github.com/cloudera/yunikorn-core/pkg/common/configs"
     "github.com/cloudera/yunikorn-core/pkg/entrypoint"
     "github.com/cloudera/yunikorn-core/pkg/log"
@@ -27,16 +28,12 @@ import (
     "time"
 )
 
-func TestSchedulerThroughput5KNodes(t *testing.T) {
-    if testing.Short() {
-        t.Skip("skipping performance testing in short mode")
-    }
-    log.InitAndSetLevel(zap.WarnLevel)
+func benchmarkScheduling(b *testing.B, numNodes, numPods int) {
+    log.InitAndSetLevel(zap.InfoLevel)
     // Start all tests
     serviceContext := entrypoint.StartAllServices()
     defer serviceContext.StopAll()
     proxy := serviceContext.RMProxy
-    // scheduler := serviceContext.Scheduler
 
     // Register RM
     configData := `
@@ -59,7 +56,7 @@ partitions:
                 vcore: 10000
 `
     configs.MockSchedulerConfigByData([]byte(configData))
-    mockRM := NewMockRMCallbackHandler(t)
+    mockRM := NewMockRMCallbackHandler(b)
 
     _, err := proxy.RegisterResourceManager(
         &si.RegisterResourceManagerRequest{
@@ -69,33 +66,30 @@ partitions:
         }, mockRM)
 
     if err != nil {
-        t.Error(err.Error())
+        b.Error(err.Error())
     }
 
-    // Register a node, and add apps
+    // Add two apps and wait for them to be accepted
     err = proxy.Update(&si.UpdateRequest{
         NewApplications: newAddAppRequest(map[string]string{"app-1":"root.a", "app-2": "root.b"}),
         RmId: "rm:123",
     })
-
-    // Check scheduling queue root
-    // schedulerQueueRoot := scheduler.GetClusterSchedulingContext().GetSchedulingQueue("root", "[rm:123]default")
-
-    // Check scheduling queue a
-    // schedulerQueueA := scheduler.GetClusterSchedulingContext().GetSchedulingQueue("root.a", "[rm:123]default")
-
     if nil != err {
-        t.Error(err.Error())
+        b.Error(err.Error())
     }
-
     waitForAcceptedApplications(mockRM, "app-1", 1000)
     waitForAcceptedApplications(mockRM, "app-2", 1000)
 
-    var newNodes []*si.NewNodeInfo
+    // Calculate node resources to make sure all required pods can be allocated
+    requestMem := 10
+    requestVcore := 1
+    numPodsPerNode := numPods / numNodes + 1
+    nodeMem := requestMem * numPodsPerNode
+    nodeVcore := requestVcore * numPodsPerNode
 
-    // register 5000 nodes
-    totalNode := 5000
-    for i:=0; i < totalNode; i++ {
+    // Register nodes
+    var newNodes []*si.NewNodeInfo
+    for i:=0; i < numNodes; i++ {
         nodeName := "node-" + strconv.Itoa(i)
         node := &si.NewNodeInfo{
             NodeId:
@@ -106,70 +100,85 @@ partitions:
             },
             SchedulableResource: &si.Resource{
                 Resources: map[string]*si.Quantity{
-                    "memory": {Value: 200},
-                    "vcore":  {Value: 20},
+                    "memory": {Value: int64(nodeMem)},
+                    "vcore":  {Value: int64(nodeVcore)},
                 },
             },
         }
-
         newNodes = append(newNodes, node)
     }
-
     err = proxy.Update(&si.UpdateRequest{
         RmId: "rm:123",
         NewSchedulableNodes: newNodes,
     })
 
+    // Wait for all nodes to be accepted
     startTime := time.Now()
-    waitForMinNumberOfAcceptedNodes(mockRM, totalNode, 5000)
+    waitForMinNumberOfAcceptedNodes(mockRM, numNodes, 5000)
     duration := time.Now().Sub(startTime)
+    b.Logf("Total time to add %d node in %s, %f per second", numNodes, duration, float64(numNodes) / duration.Seconds())
 
-    t.Logf("Total time to add %d node %s, %f per second", totalNode, duration, float64(totalNode) / duration.Seconds())
-
-    // Get scheduling app
-    // schedulingApp := scheduler.GetClusterSchedulingContext().GetSchedulingApplication("app-1", "[rm:123]default")
-
+    // Request pods
+    app1NumPods := numPods / 2
     err = proxy.Update(&si.UpdateRequest{
         Asks: []*si.AllocationAsk{
             {
                 AllocationKey: "alloc-1",
                 ResourceAsk: &si.Resource{
                     Resources: map[string]*si.Quantity{
-                        "memory": {Value: 10},
-                        "vcore":  {Value: 1},
+                        "memory": {Value: int64(requestMem)},
+                        "vcore":  {Value: int64(requestVcore)},
                     },
                 },
-                MaxAllocations: 200000,
+                MaxAllocations: int32(app1NumPods),
                 ApplicationId:  "app-1",
             },
         },
         RmId: "rm:123",
     })
-
     err = proxy.Update(&si.UpdateRequest{
         Asks: []*si.AllocationAsk{
             {
                 AllocationKey: "alloc-1",
                 ResourceAsk: &si.Resource{
                     Resources: map[string]*si.Quantity{
-                        "memory": {Value: 10},
-                        "vcore":  {Value: 1},
+                        "memory": {Value: int64(requestMem)},
+                        "vcore":  {Value: int64(requestVcore)},
                     },
                 },
-                MaxAllocations: 200000,
+                MaxAllocations: int32(numPods-app1NumPods),
                 ApplicationId:  "app-2",
             },
         },
         RmId: "rm:123",
     })
 
-    // test number of allocations, should be less than or equal to 100000 (200 * 5000 / 10)
-    testNumAllocations := 10000
-
-    // Wait for maximum 2 mins
+    // Reset number of iterations and timer for this benchmark
+    b.N = numPods
     startTime = time.Now()
-    waitForMinAllocations(mockRM, testNumAllocations, 120000)
+    b.ResetTimer()
+
+    // Wait for all pods to be allocated
+    waitForMinAllocations(mockRM, numPods, 120000)
+
+    // Stop timer and calculate duration
+    b.StopTimer()
     duration = time.Now().Sub(startTime)
 
-    t.Logf("Total time to allocate %d containers in %s, %f per second", testNumAllocations, duration, float64(testNumAllocations) / duration.Seconds())
+    b.Logf("Total time to allocate %d containers in %s, %f per second", numPods, duration, float64(numPods) / duration.Seconds())
+}
+
+func BenchmarkScheduling(b *testing.B) {
+    tests := []struct{ numNodes, numPods int }{
+        {numNodes: 500, numPods: 10000},
+        {numNodes: 1000, numPods: 10000},
+        {numNodes: 2000, numPods: 10000},
+        {numNodes: 5000, numPods: 10000},
+    }
+    for _, test := range tests {
+        name := fmt.Sprintf("%vNodes/%vPods", test.numNodes, test.numPods)
+        b.Run(name, func(b *testing.B) {
+            benchmarkScheduling(b, test.numNodes, test.numPods)
+        })
+    }
 }

--- a/pkg/scheduler/tests/schedulertestutils.go
+++ b/pkg/scheduler/tests/schedulertestutils.go
@@ -28,7 +28,7 @@ import (
 )
 
 type MockRMCallbackHandler struct {
-    t *testing.T
+    t testing.TB
 
     acceptedApplications map[string]bool
     rejectedApplications map[string]bool
@@ -40,7 +40,7 @@ type MockRMCallbackHandler struct {
     lock sync.RWMutex
 }
 
-func NewMockRMCallbackHandler(t *testing.T) *MockRMCallbackHandler {
+func NewMockRMCallbackHandler(t testing.TB) *MockRMCallbackHandler {
     return &MockRMCallbackHandler{
         t:                    t,
         acceptedApplications: make(map[string]bool),

--- a/pkg/scheduler/tests/schedulertestutils.go
+++ b/pkg/scheduler/tests/schedulertestutils.go
@@ -275,7 +275,7 @@ func waitForMinAllocations(m *MockRMCallbackHandler, nAlloc int, timeoutMs int) 
         m.lock.RUnlock()
 
 
-        if allocLen != nAlloc {
+        if allocLen < nAlloc {
             time.Sleep(time.Millisecond)
         } else {
             return


### PR DESCRIPTION
Glad to see scheduler perf test is added, it is useful for us to know scheduling abilities quickly and debug the scheduling perf locally, I have some suggestions about this:
1. Now this test doesn't contain verification about correctness and will last for a few seconds, we have to wait more time to execute 'make test', I suppose to mark this test as non-short and default run 'go test -short'
2. Too many DEBUG logs will be printed in console when running this test, we can change log level dynamically to avoid this.
3. totalAllocations in the test should be 100000 instead of 10000, here I think it's better to adjust the test scale and don't have to wait all allocations are done. For waitForMinAllocations in schedulertestutils.go, we can replace the sleep condition 'allocLen != nAlloc' with 'allocLen < nAlloc' to end this test in advance.

@wangdatan @yangwwei , could you please help to review this init PR, hope to hear your thoughts and improve it later,  Thanks.