### PR TITLE
Make sure config watcher can be stopped in time

### DIFF
--- a/pkg/common/configs/configwatcher.go
+++ b/pkg/common/configs/configwatcher.go
@@ -117,6 +117,7 @@ func (cw *ConfigWatcher) Run() {
 					ticker.Stop()
 					return
 				default:
+					break
 				}
 				select {
 				case <-ticker.C:
@@ -124,6 +125,10 @@ func (cw *ConfigWatcher) Run() {
 						<-cw.soloChan
 						return
 					}
+				case <-quit:
+					<-cw.soloChan
+					ticker.Stop()
+					return
 				}
 			}
 		}()

--- a/pkg/common/configs/configwatcher.go
+++ b/pkg/common/configs/configwatcher.go
@@ -112,15 +112,18 @@ func (cw *ConfigWatcher) Run() {
 		go func() {
 			for {
 				select {
+				case <-quit:
+					<-cw.soloChan
+					ticker.Stop()
+					return
+				default:
+				}
+				select {
 				case <-ticker.C:
 					if !cw.runOnce() {
 						<-cw.soloChan
 						return
 					}
-				case <-quit:
-					<-cw.soloChan
-					ticker.Stop()
-					return
 				}
 			}
 		}()


### PR DESCRIPTION
This is a trivial improvement for config watcher to make sure it can be stopped in time and can solve  #62 (TestConfigWatcherExpiration UT fails intermittently).