### PR TITLE
Format metric names of node usage to avoid validation failures

### DIFF
--- a/pkg/metrics/init.go
+++ b/pkg/metrics/init.go
@@ -133,7 +133,9 @@ func GetQueueMetrics(name string) CoreQueueMetrics {
 	}
 }
 
-func FormatMetricName(metricName string) string {
+// Format metric name based on the definition of metric name in prometheus, as per
+// https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+func formatMetricName(metricName string) string {
 	if len(metricName) == 0 {
 		return metricName
 	}

--- a/pkg/metrics/init.go
+++ b/pkg/metrics/init.go
@@ -26,6 +26,8 @@ const (
 	Namespace = "yunikorn"
 	// SchedulerSubsystem - subsystem name used by scheduler
 	SchedulerSubsystem = "scheduler"
+	// replacement of invalid byte for prometheus metric names
+	MetricNameInvalidByteReplacement = '_'
 )
 
 var once sync.Once
@@ -128,5 +130,25 @@ func GetQueueMetrics(name string) CoreQueueMetrics {
 		queueMetrics := forQueue(name)
 		m.queues[name] = queueMetrics
 		return queueMetrics
+	}
+}
+
+func FormatMetricName(metricName string) string {
+	if len(metricName) == 0 {
+		return metricName
+	}
+	newBytes := make([]byte, len(metricName))
+	for i := 0; i < len(metricName); i++ {
+		b := metricName[i]
+		if !((b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || b == ':' || (b >= '0' && b <= '9')) {
+			newBytes[i] = MetricNameInvalidByteReplacement
+		} else {
+			newBytes[i] = b
+		}
+	}
+	if '0' <= metricName[0] && metricName[0] <= '9' {
+		return string(MetricNameInvalidByteReplacement) + string(newBytes)
+	} else {
+		return string(newBytes)
 	}
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 Cloudera, Inc.  All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+    "github.com/prometheus/common/model"
+    "gotest.tools/assert"
+    "math/rand"
+    "testing"
+)
+
+func TestFormatMetricName(t *testing.T) {
+    testStrings := []string{"0", "ad_vs:ad", "~23", "test/a", "-dfs", "012~`s@dd#$b%23^&5^3*(45){78}|00[]\\1ssd"}
+    for _, testString := range testStrings {
+        replaceStr := FormatMetricName(testString)
+        assert.Equal(t, true, model.IsValidMetricName(model.LabelValue(replaceStr)))
+    }
+    numRandomTestStrings := 1000
+    randomTestStrings := make([]string, numRandomTestStrings)
+    for i := 0; i < numRandomTestStrings; i++ {
+        randomTestStrings[i] = generateRandomString(100)
+    }
+    for _, testString := range randomTestStrings {
+        replaceStr := FormatMetricName(testString)
+        assert.Equal(t, true, model.IsValidMetricName(model.LabelValue(replaceStr)))
+    }
+}
+
+func generateRandomString(len int) string {
+    randomBytes := make([]byte, len)
+    rand.Read(randomBytes)
+    return string(randomBytes)
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -26,7 +26,7 @@ import (
 func TestFormatMetricName(t *testing.T) {
     testStrings := []string{"0", "ad_vs:ad", "~23", "test/a", "-dfs", "012~`s@dd#$b%23^&5^3*(45){78}|00[]\\1ssd"}
     for _, testString := range testStrings {
-        replaceStr := FormatMetricName(testString)
+        replaceStr := formatMetricName(testString)
         assert.Equal(t, true, model.IsValidMetricName(model.LabelValue(replaceStr)))
     }
     numRandomTestStrings := 1000
@@ -35,7 +35,7 @@ func TestFormatMetricName(t *testing.T) {
         randomTestStrings[i] = generateRandomString(100)
     }
     for _, testString := range randomTestStrings {
-        replaceStr := FormatMetricName(testString)
+        replaceStr := formatMetricName(testString)
         assert.Equal(t, true, model.IsValidMetricName(model.LabelValue(replaceStr)))
     }
 }

--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -91,9 +91,8 @@ func forQueue(name string) CoreQueueMetrics {
 }
 
 func substituteQueueName(queueName string) string {
-	str := fmt.Sprintf("queue_%s",
+	return fmt.Sprintf("queue_%s",
 		strings.Replace(queueName, ".", "_", -1))
-	return strings.Replace(str, "-", "_", -1)
 }
 
 func (m *QueueMetrics) IncApplicationsAccepted() {

--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -91,8 +91,9 @@ func forQueue(name string) CoreQueueMetrics {
 }
 
 func substituteQueueName(queueName string) string {
-	return fmt.Sprintf("queue_%s",
+	str := fmt.Sprintf("queue_%s",
 		strings.Replace(queueName, ".", "_", -1))
+	return strings.Replace(str, "-", "_", -1)
 }
 
 func (m *QueueMetrics) IncApplicationsAccepted() {

--- a/pkg/metrics/scheduler.go
+++ b/pkg/metrics/scheduler.go
@@ -330,7 +330,7 @@ func (m *SchedulerMetrics) SetNodeResourceUsage(resourceName string, rangeIdx in
 	var resourceMetrics *prometheus.GaugeVec
 	resourceMetrics, ok := m.nodesResourceUsages[resourceName]
 	if !ok {
-		metricsName := fmt.Sprintf("%s_nodes_usage", FormatMetricName(resourceName))
+		metricsName := fmt.Sprintf("%s_nodes_usage", formatMetricName(resourceName))
 		resourceMetrics = prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   Namespace,

--- a/pkg/metrics/scheduler.go
+++ b/pkg/metrics/scheduler.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cloudera/yunikorn-core/pkg/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
-	"strings"
 	"sync"
 	"time"
 )
@@ -331,7 +330,7 @@ func (m *SchedulerMetrics) SetNodeResourceUsage(resourceName string, rangeIdx in
 	var resourceMetrics *prometheus.GaugeVec
 	resourceMetrics, ok := m.nodesResourceUsages[resourceName]
 	if !ok {
-		metricsName := strings.Replace(fmt.Sprintf("%s_nodes_usage", resourceName), "-", "_", -1)
+		metricsName := fmt.Sprintf("%s_nodes_usage", FormatMetricName(resourceName))
 		resourceMetrics = prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   Namespace,


### PR DESCRIPTION
Names of node resource on K8s may contain some invalid characters for prometheus, for example: 'group/name' or 'group.name', we may encounter validation failures when registering node usage metrics. 
This PR proposes to Format metric names via replacing invalid characters(not in alpha-beta, numeric, '_' and ':' characters) with '\_' and add the prefix '\_' when metric name starts with a number.